### PR TITLE
Add group website link to header nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,7 @@ markdown_extensions:
       generic: true
 
 nav:
+  - Group Website: https://comp-physics.group
   - Home: index.md
   - Syllabus:
     - Welcome: group-syllabus/intro-to-group.md


### PR DESCRIPTION
Adds a 'Group Website' link in the header nav pointing to comp-physics.group.