### PR TITLE
Update group docs for the move to UT Austin

### DIFF
--- a/docs/group-syllabus/challenges.md
+++ b/docs/group-syllabus/challenges.md
@@ -11,7 +11,7 @@ It is possible that you will experience some form of chronic anxiety at some poi
 This feeling is common, and many students will experience it at some point or another.
 Don't be alarmed; if you are comfortable with it, come to talk to me (or others) if you feel this way.
 
-The environment in academia, including at Georgia Tech, _will not stop you_ from overworking at the cost of your well-being.
+The environment in academia _will not stop you_ from overworking at the cost of your well-being.
 Quite the opposite, you will often feel like academic work culture encourages working evenings and weekends, and many do (I do).
 However, _overworking_ is neither healthy nor productive in the long run as an undergraduate or Ph.D. researcher.
 Note that the specific definition, in terms of say, hours worked, will vary person-to-person, and can change as your life otherwise changes in various ways.

--- a/docs/group-syllabus/faq.md
+++ b/docs/group-syllabus/faq.md
@@ -56,7 +56,7 @@ Of course, I understand research has natural ebbs and flows.
 
 ### What computing resources are available?
 
-Our group has access to various computing resources, like Georgia Tech's PACE cluster and external supercomputing facilities.
+Our group has access to various computing resources, like campus clusters and external supercomputing facilities.
 See [Available computers](computers.md) for specific information.
 
 ### Is there funding for conferences?

--- a/docs/group-syllabus/funding.md
+++ b/docs/group-syllabus/funding.md
@@ -32,6 +32,6 @@ Not a bad situation to be in.
 
 ## Stipend
 
-Your stipend is determined by the Graduate School at Georgia Tech.
+Your stipend is determined by the Graduate School.
 The Ph.D. stipend is by no means a lot of money, but I believe people have found that it supports a comfortable life that allows you to focus on your studies.
 On a related note, there is an expectation that your Ph.D. will be your full-time work, though internships, particularly during the summer, are possible and sometimes recommended.

--- a/docs/group-syllabus/funding.md
+++ b/docs/group-syllabus/funding.md
@@ -4,7 +4,7 @@
 If you are an undergraduate, [click here](undergraduate-specifics.md).
 
 Your Ph.D. comes with guaranteed funding (i.e., stipend, tuition, health insurance) while you are in the program.
-This means you are guaranteed to have a fellowship, Graduate Research Assistantship (RA), or Teaching Assistantship (TA) to support you throughout your time at Georgia Tech.
+This means you are guaranteed to have a fellowship, Graduate Research Assistantship (RA), or Teaching Assistantship (TA) to support you throughout your time here.
 You also do not pay to attend conferences, this is covered via research funds.
 
 ## Research and Teaching Assistantship

--- a/docs/group-syllabus/giving-talks.md
+++ b/docs/group-syllabus/giving-talks.md
@@ -8,7 +8,7 @@ Giving a talk is presumably associated with some goals, otherwise, why give it?
 You should organize your talk to achieve these goals.
 Here are some examples of things you might want people to think after your talk:
 
-* I saw a nice talk about X from this person Y at Georgia Tech. We should look more into what they're up to (or talk to them after the talk)
+* I saw a nice talk about X from this person Y on campus. We should look more into what they're up to (or talk to them after the talk)
 * This talk was about X and the main results were Y. (You will find many talks do not meet this seemingly low bar)
 * This work was about X and I'm also working in X! They're doing Y and we're doing Z. Maybe we can collaborate and improve X together.
 * This talk was great — who is this person? (then they remember your name and will use it at a later date, perhaps for hiring purposes)

--- a/docs/group-syllabus/going-to-conferences.md
+++ b/docs/group-syllabus/going-to-conferences.md
@@ -32,7 +32,7 @@ They do not have a talk to give or an abstract or poster to present.
 This can be a nice learning experience, and I would love to send all students to all conferences (more or less).
 However, this can be extremely expensive (more than you might realize).
 This can also hinder my ability to later send you to more conferences where you _will_ have papers to present.
-As a result, I do not support "observation" conference attendance with my own research funds, though sometimes you can win a conference attendance grant (these are conference-specific, and PURA Travel is not sufficient for undergraduate researchers).
+As a result, I do not support "observation" conference attendance with my own research funds, though sometimes you can win a conference attendance grant (these are conference-specific).
 
 ## Registration, flights, and hotels
 

--- a/docs/group-syllabus/going-to-conferences.md
+++ b/docs/group-syllabus/going-to-conferences.md
@@ -49,27 +49,6 @@ We know we are attending conferences many months in advance, so there is little 
 
 * Per diem: You will be reimbursed for your meals via the per diem rate for the conference location.
 
-## Spend authorization
-
-If you are a graduate student employee (on a GRA: Graduate Research Assistantship), you need a spend authorization to be approved by Georgia Tech before going to a conference.
-To file a spend authorization, go to [Workday](https://wd5.myworkday.com/gatech/d/home.htmld), log in with your GT credentials, and type `Create Spend Authorization` in the search bar at the top of the page.
-This should take you to a web form to fill out.
-
-An example of how to fill this out
-
-* Start Date: A day before you leave for the conference
-* End Date: The day after you return from the conference
-* Description: Travel to attend and give a talk at X conference
-* Business Purpose: Conference/seminar (should autofill)
-
-Click `Add` under `Spend Authorization Lines`
-
-* Expense item: `Miscellaneous - Domestic` or `Miscellaneous - International` (depending on if international or not)
-* Total amount: about 20% more than your actual planned expenses
-* Grant: I will give you a number to copy-paste into here, then link 'Enter,' and it should auto-populate most other fields.
-
-That's it! Ask your colleagues if you have questions, and ask me if they don't know the answer.
-
 ## Actually going to the conference
 
 Once you have identified the conference you want to attend, the next steps are:  

--- a/docs/group-syllabus/hardware.md
+++ b/docs/group-syllabus/hardware.md
@@ -3,7 +3,7 @@
 
 During your Ph.D. or, sometimes, undergraduate work, you will acquire hardware that appears to be "from me" to assist with your research.
 This hardware is funded by a grant or some other money issued to my research program through the institute.
-Georgia Tech owns all work and hardware conducted under the auspices of Georgia Tech.
+The university owns all work and hardware conducted under its auspices.
 Thus, _you do not own the laptop, workstation, or any other hardware issued to you_ for research purposes (I also do not own it!).
 As such, you are required to return all hardware upon graduation or when leaving the research group.
 Given this, it is your responsibility to __take care of the hardware issued to you, not physically abusing or modifying it__.

--- a/docs/group-syllabus/intro-to-group.md
+++ b/docs/group-syllabus/intro-to-group.md
@@ -7,19 +7,14 @@ This document has some parts that are specific to Ph.D. students, but much of it
 
 ## Getting started
 
-### CODA
+### Oden Institute building
 
-You will need access to the CODA building.
-GT CSE is on floor 13, and our group is in room S1347.
-We also hold meetings either in my office (S1313) or one of the conference rooms on the 13th floor.
+You will need access to the Oden Institute building, where the group space and my office are.
+We hold meetings either in my office or in one of the nearby conference rooms.
 Request this from Spencer.
-Send him your GTID number. Though times vary, it will likely take a week to "start working."
+Send him your university ID number. Though times vary, it will likely take a week to "start working."
 
 ### Websites, software, course numbers, and such
-
-* Box, located [here](https://gatech.app.box.com/folder/142416587982)
-    * Purpose: Common location to store things, unlimited space. Put your group and 1-1 updates here.
-    * Request access to group Box from Spencer.
 
 * GitHub organization, located [here](https://github.com/comp-physics)
     * Purpose: Your code goes here. Keep it up-to-date via commits. I will likely bug you if you don't update your codes via regular commits as you progress.
@@ -31,7 +26,7 @@ Send him your GTID number. Though times vary, it will likely take a week to "sta
     * Request access from Spencer.
 
 * Group email list
-   * Upon joining, remind Spencer to add you to the `comp-physics@office365.gatech.edu` email list
+   * Upon joining, remind Spencer to add you to the group email list
 
 * Group website, located [here](https://comp-physics.group/team/)
    * Send Spencer a headshot and your LinkedIn, ResearchGate, personal/research website, Google Scholar, etc. for the website

--- a/docs/group-syllabus/publishing.md
+++ b/docs/group-syllabus/publishing.md
@@ -74,7 +74,7 @@ Use Overleaf when writing your journal and conference papers so we can collabora
 Overleaf has a feature that allows you to hook a local copy to the Overleaf one via `git` or GitHub.
 I use the raw `git` interface so I can use `vim` for my typing and compiling locally, then pushing changes to the document.
 This is particularly useful for generating the `.pdf` files for independent `tikz`/`pgfplots` figures.
-You get a free Overleaf Pro account with your `gatech.edu` email address.
+You get a free Overleaf Pro account with your `utexas.edu` email address.
 
 ## Co-authorship
 

--- a/docs/group-syllabus/responding-to-reviewers.md
+++ b/docs/group-syllabus/responding-to-reviewers.md
@@ -53,4 +53,3 @@ There are examples in this repository, including
 * A Revision template [in this directory](https://github.com/comp-physics/group-docs/tree/master/templates/paper_rebuttal)
 
 * In the same place is a `Makefile` that uses the `latexdiff` tool to create a `diff` between the submitted (`main.tex`) and revised (`main_rev.tex`) manuscript files in the form of a new PDF file called `diff.pdf`. This shows the reviewer explicitly all the changes you made to improve the paper (on top of the revisions in the response to the reviewers document).
-

--- a/docs/group-syllabus/responding-to-reviewers.md
+++ b/docs/group-syllabus/responding-to-reviewers.md
@@ -54,4 +54,3 @@ There are examples in this repository, including
 
 * In the same place is a `Makefile` that uses the `latexdiff` tool to create a `diff` between the submitted (`main.tex`) and revised (`main_rev.tex`) manuscript files in the form of a new PDF file called `diff.pdf`. This shows the reviewer explicitly all the changes you made to improve the paper (on top of the revisions in the response to the reviewers document).
 
-* Example diffs and responses to reviewers for some of my papers are located [here](https://gatech.app.box.com/folder/245228437856)

--- a/docs/group-syllabus/undergraduate-specifics.md
+++ b/docs/group-syllabus/undergraduate-specifics.md
@@ -22,15 +22,10 @@ You can be paid a modest sum as an undergraduate researcher.
 This comes in the form of funding routed through either
 
 * A federal grant (via Spencer)
-* A salary award from Georgia Tech, called [PURA Salary](https://urop.gatech.edu/pura-salary).
+* An undergraduate research award from the university
 
-I generally expect you to apply for PURA Salary before requesting funds from a sponsored grant.
-Deadlines are often _early_, about 3.5 months before the semester of the award.
-For example:
-> SPRING 2024 APPLICATION DEADLINE  
-> FRIDAY, September 29, 2023
-
-Details on the review rubric for PURA Salary are available from the [PURA website](https://urop.gatech.edu/pura-salary).
+I generally expect you to apply for a university award before requesting funds from a sponsored grant.
+Deadlines for these are often _early_, well before the semester of the award, so ask about them in advance.
 
 I do not fund undergraduate researchers during their first semester or year working with the group.
 This is primarily due to the start-up time required to get familiar with any project and contribute more directly.
@@ -52,7 +47,7 @@ GT CS offers an undergraduate thesis option, which meets several degree requirem
 
 Some commitment topics to consider:
 
-* If you hope to go to a top graduate school (or are considering it), at Georgia Tech or otherwise, completing your degree early is unlikely to help with admission, but completing high-quality research _definitely_ will.
+* If you hope to go to a top graduate school (or are considering it), here or elsewhere, completing your degree early is unlikely to help with admission, but completing high-quality research _definitely_ will.
 * If you don't think you want to go to graduate school, research can still expand industry opportunities. The degree to which it expands those opportunities will depend on the job you hope to obtain. Discuss with Spencer for more details.
 
 ## Outcomes
@@ -104,8 +99,5 @@ If you are not making consistent contact with your colleagues, I will notice and
 
 If you have made significant research progress, you can present it at a conference!
 I have sent several undergraduates to conferences; nearly all UGs that worked with the group for > 1 year.
-You should apply for [PURA Travel](https://urop.gatech.edu/pura-travel).
-> Applications are to be submitted no earlier than three months before the anticipated conference date and no later than one month before the anticipated conference date.
-
-It is a rather short proposal that is easy to put together.
+Ask Spencer about undergraduate travel awards, which usually have their own deadlines relative to the conference date.
 Undergraduates __do not__ need to complete a spend authorization (but graduate students do).

--- a/docs/group-syllabus/undergraduate-specifics.md
+++ b/docs/group-syllabus/undergraduate-specifics.md
@@ -25,7 +25,6 @@ This comes in the form of funding routed through either
 * A salary award from Georgia Tech, called [PURA Salary](https://urop.gatech.edu/pura-salary).
 
 I generally expect you to apply for PURA Salary before requesting funds from a sponsored grant.
-Some example proposals for the salary award are located [on the Box](https://gatech.app.box.com/folder/227839379429).
 Deadlines are often _early_, about 3.5 months before the semester of the award.
 For example:
 > SPRING 2024 APPLICATION DEADLINE  
@@ -89,8 +88,8 @@ I recommend you talk about this with me so I can give more personalized guidance
 
 ## Office space
 
-You will have a desk to use, including a 32" 4K monitor, keyboard, and mouse, in the group office space on the 13th floor of CODA.
-You are always welcome to use the CODA spaces on the 13th floor or otherwise.
+You will have a desk to use, including a 32" 4K monitor, keyboard, and mouse, in the group office space in the Oden Institute building.
+You are always welcome to use the Oden Institute common spaces.
 These areas seem quite pleasant to me, but you may disagree.
 If you would like somewhere to work but are still looking for a comfortable place, please let me know.
 
@@ -109,5 +108,4 @@ You should apply for [PURA Travel](https://urop.gatech.edu/pura-travel).
 > Applications are to be submitted no earlier than three months before the anticipated conference date and no later than one month before the anticipated conference date.
 
 It is a rather short proposal that is easy to put together.
-Some example successful proposals are [here](https://gatech.app.box.com/folder/227839379429).
-Undergraduates __do not__ need to complete a Georgia Tech Spend Authorization (but graduate students do).
+Undergraduates __do not__ need to complete a spend authorization (but graduate students do).

--- a/docs/group-syllabus/when-where-working.md
+++ b/docs/group-syllabus/when-where-working.md
@@ -52,17 +52,17 @@ Two caveats:
 
 ## Work location
 
-We work in CODA, which has an open space layout, and the group's students sit near each other.
-You will have an assigned desk in or near room S1347.
-Our CODA space also has many open rooms, couches, desks, food and coffee options, etc.
+We work in the Oden Institute building, which has an open space layout, and the group's students sit near each other.
+You will have an assigned desk in or near the group area.
+Our space also has many open rooms, couches, desks, food and coffee options, etc.
 Hopefully, this makes it a desirable place to work! (if not, or if something could be improved, please let me know!)
-If you are an undergraduate student without a permanent desk in CODA, I may request one if you spend significant time working on group research.
+If you are an undergraduate student without a permanent desk in our space, I may request one if you spend significant time working on group research.
 As available space grows and wanes, the possibility of permanent desks for undergraduate student researchers may also change.
 Still, please do ask if you would like to spend significant time researching from our group area!
-Even if you don't have a desk, feel free to use the CODA 13th-floor space regularly.
+Even if you don't have a desk, feel free to use the Oden Institute common spaces regularly.
 I find it quite nice, personally!
 
-I spend most of my time in my office, S1313, near the group desks.
+I spend most of my time in my office, near the group desks.
 I expect most students to work from their desks regularly, not to say "most of the time," but perhaps a substantial portion of their working hours each week.
 Most student researchers come in at least 3 days a week.
 

--- a/docs/group-syllabus/working-with-me.md
+++ b/docs/group-syllabus/working-with-me.md
@@ -72,8 +72,7 @@ You may also see me in project-specific meetings (the frequency of which depends
 ## How to get a hold of me
 
 Our group Slack workspace is the best way to find me if I'm not in my office.
-My calendar is always available to the public [via this link](https://outlook.office365.com/calendar/published/89a8b6b3591343ecb432e9a56a04e5f3@gatech.edu/8133a21aea4c4970b3049d3fffee2c066536954178697437005/calendar.html).
-You can use it to strategize times you might want to stop by the Oden Institute if you think it would be useful to chat with me, though an empty time on my calendar does not guarantee that I will be in my office.
+If you think it would be useful to chat, you are welcome to stop by the Oden Institute, though I am not always in my office.
 Checking via Slack is more reliable.
 
 __Note:__ If you want me to be responsive to you, you should be responsive to me.

--- a/docs/group-syllabus/working-with-me.md
+++ b/docs/group-syllabus/working-with-me.md
@@ -73,7 +73,7 @@ You may also see me in project-specific meetings (the frequency of which depends
 
 Our group Slack workspace is the best way to find me if I'm not in my office.
 My calendar is always available to the public [via this link](https://outlook.office365.com/calendar/published/89a8b6b3591343ecb432e9a56a04e5f3@gatech.edu/8133a21aea4c4970b3049d3fffee2c066536954178697437005/calendar.html).
-You can use it to strategize times you might want to stop by CODA if you think it would be useful to chat with me, though an empty time on my calendar does not guarantee that I will be in my office.
+You can use it to strategize times you might want to stop by the Oden Institute if you think it would be useful to chat with me, though an empty time on my calendar does not guarantee that I will be in my office.
 Checking via Slack is more reliable.
 
 __Note:__ If you want me to be responsive to you, you should be responsive to me.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Computational Physics @ GT: Group Documentation
 
-Welcome! This is the documentation for the Computational Physics research group at Georgia Tech.
+Welcome! This is the documentation for the Computational Physics research group.
 
 **Getting started?** Head to [Welcome to the group!](group-syllabus/intro-to-group.md)
 

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Computational Physics @ GT Group Documentation
 
-Documentation for the Computational Physics research group at Georgia Tech.
+Documentation for the Computational Physics research group.
 
 **[Read the docs here](https://comp-physics.group/group-docs/)**
 

--- a/templates/paper/main.tex
+++ b/templates/paper/main.tex
@@ -17,11 +17,11 @@
 
 \author[1]{Your Name}
 \author[2,3]{Spencer H.\ Bryngelson}
-\ead{shb@gatech.edu}
+\ead{shb@utexas.edu}
 
-\address[1]{Some other School, Georgia Institute of Technology, Atlanta, GA 30332, USA\vspace{-0.15cm}}
-\address[2]{Daniel Guggenheim School of Aerospace Engineering, Georgia Institute of Technology, Atlanta, GA 30332, USA\vspace{-0.15cm}}
-\address[3]{School of Computational Science \& Engineering, Georgia Institute of Technology, Atlanta, GA 30332, USA}
+\address[1]{Some other Department, The University of Texas at Austin, Austin, TX 78712, USA\vspace{-0.15cm}}
+\address[2]{Walker Department of Mechanical Engineering, The University of Texas at Austin, Austin, TX 78712, USA\vspace{-0.15cm}}
+\address[3]{Oden Institute for Computational Engineering and Sciences, The University of Texas at Austin, Austin, TX 78712, USA}
 
 \date{}
 


### PR DESCRIPTION
Updates the group syllabus and templates for the move from Georgia Tech to UT Austin.

## Changed

- **`templates/paper/main.tex`** — author email to `shb@utexas.edu`; the three `\address` lines are now Walker Department of Mechanical Engineering, Oden Institute, UT Austin (Austin, TX 78712).
- **`readme.md`, `docs/index.md`** — group description drops "at Georgia Tech", matching the website.
- **CODA to the Oden Institute building** — `intro-to-group.md`, `when-where-working.md`, `undergraduate-specifics.md`, `working-with-me.md`. GT room and floor numbers (S1313, S1347, "13th floor") are dropped rather than guessed at, as are the GTID reference and the `comp-physics@office365.gatech.edu` list address.
- **Box removed entirely** — the storage bullet in `intro-to-group.md`, the example reviewer responses in `responding-to-reviewers.md`, and two example-proposal links in `undergraduate-specifics.md`.
- **Workday removed entirely** — the whole `## Spend authorization` walkthrough in `going-to-conferences.md`. The related line in `undergraduate-specifics.md` is now institution-neutral.
- **PURA removed** — PURA Salary and PURA Travel are GT undergraduate award programs with no UT equivalent named yet. The walkthroughs are replaced with a pointer to ask about university undergraduate research and travel awards.
- **Overleaf** — `publishing.md` now says `utexas.edu`; the Pro license carries over.
- **Calendar link removed** — the published calendar in `working-with-me.md` was on the GT Outlook tenant and would stop resolving. That paragraph now just says to stop by or check Slack.
- **Passing GT mentions genericized** — `hardware.md` (IP ownership), `funding.md` (Graduate School, "your time here"), `challenges.md`, `giving-talks.md`, `faq.md`, `undergraduate-specifics.md`, `going-to-conferences.md`.

## Deliberately left alone

- **`computers.md`** — the `## Georgia Tech` section (PACE Phoenix, ICE, Rogues Gallery, Wingtip) stays as-is for now. The ACCESS-CI, DOE, and DOD sections were already institution-neutral.

`mkdocs build --strict` passes. Outside `computers.md`, no `gatech`, `Georgia Tech`, `CODA`, `PURA`, Box, or Workday references remain.