### PR TITLE
Drop @ GT from the docs branding

### DIFF
--- a/docs/group-syllabus/intro-to-group.md
+++ b/docs/group-syllabus/intro-to-group.md
@@ -1,5 +1,5 @@
 
-# Welcome to the Computational Physics @ GT CSE research group!
+# Welcome to the Computational Physics research group!
 
 The most important thing about this document is that I/we are _very glad_ to have you.
 You wouldn't be a part of the group otherwise.

--- a/docs/group-syllabus/undergraduate-specifics.md
+++ b/docs/group-syllabus/undergraduate-specifics.md
@@ -43,7 +43,7 @@ I expect undergraduate researchers in the group to take fewer classes than they 
 This amounts to, at most, 4 serious classes per term while conducting research.
 Taking fewer classes might mean graduating in 4 years instead of 3 (or something akin to this).
 You must consider this trade-off on your terms, though I'm glad to discuss it with you.
-GT CS offers an undergraduate thesis option, which meets several degree requirements but is otherwise a small time commitment (and teaches you useful things!).
+Your department may offer an undergraduate thesis option, which meets several degree requirements but is otherwise a small time commitment (and teaches you useful things!).
 
 Some commitment topics to consider:
 
@@ -66,7 +66,7 @@ __It takes about two years to research and write a journal paper, plus additiona
 
 ## Ph.D.?
 
-If you are interested in continuing to a Ph.D. at GT or elsewhere, there are a few extra things worth noting.
+If you are interested in continuing to a Ph.D. here or elsewhere, there are a few extra things worth noting.
 
 * Having a journal or conference paper(s) in top venues will strongly improve your chances of admission.
 * Having _extremely_ strong references, even just one(!) (in this case, likely me), can get you into a top Ph.D. program. I will write a letter faithful to your work with me and the group.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# Computational Physics @ GT: Group Documentation
+# Computational Physics Group Documentation
 
 Welcome! This is the documentation for the Computational Physics research group.
 

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -4,7 +4,7 @@
   <div class="cp-navbar">
     <a class="cp-navbar-brand" href="https://comp-physics.group">
       <img src="https://comp-physics.group/favicon.ico" width="30" height="30" alt="">
-      Computational Physics @ GT
+      Computational Physics Group
     </a>
     <nav class="cp-navbar-links">
       <a href="https://comp-physics.group">Home</a>

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# Computational Physics @ GT Group Documentation
+# Computational Physics Group Documentation
 
 Documentation for the Computational Physics research group.
 


### PR DESCRIPTION
Follow-up to #46. The docs site header still read **Computational Physics @ GT**.

The earlier pass grepped for `Georgia Tech`, `Georgia Institute`, and `gatech`, none of which match the string `@ GT` — the same blind spot that left the website footer's hardcoded copyright behind.

## Changed

- **`overrides/main.html`** — the navbar brand, which is what actually renders at the top of every docs page
- **`readme.md`, `docs/index.md`** — page titles
- **`intro-to-group.md`** — "Welcome to the Computational Physics @ GT CSE research group!"
- **`undergraduate-specifics.md`** — "GT CS offers an undergraduate thesis option" is now "Your department may offer...", and "a Ph.D. at GT or elsewhere" is now "here or elsewhere"

Branding drops the university entirely rather than swapping in UT Austin, matching the website.

`markdownlint-cli2` clean, `mkdocs build --strict` passes. Outside `computers.md`, no `GT`, `Georgia Tech`, or `gatech` references remain.