### PR TITLE
Shift the accent to burnt orange

### DIFF
--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -1,5 +1,5 @@
-/* Accent gold #c0995e and light gold #d4b07c match --gold / --gold-light in
-   the website's _sass/SHB_css.scss. Keep the two in sync. */
+/* Accent #d98a45 and light #e2a773 match --gold / --gold-light in the
+   website's _sass/SHB_css.scss. Keep the two in sync. */
 
 @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&display=swap');
 
@@ -7,8 +7,8 @@
   --md-primary-fg-color: #262829;
   --md-primary-fg-color--light: #343a40;
   --md-primary-fg-color--dark: #262829;
-  --md-accent-fg-color: #c0995e;
-  --md-accent-fg-color--transparent: #c0995e1a;
+  --md-accent-fg-color: #d98a45;
+  --md-accent-fg-color--transparent: #d98a451a;
 }
 
 [data-md-color-scheme="slate"] {
@@ -39,50 +39,50 @@
 }
 
 a {
-  color: #c0995e;
+  color: #d98a45;
 }
 
 a:visited {
-  color: #c0995e;
+  color: #d98a45;
 }
 
 a:hover {
-  color: #d4b07c;
+  color: #e2a773;
 }
 
 .md-nav__link--active,
 .md-nav__link:visited,
 .md-nav__link:hover {
-  color: #c0995e;
+  color: #d98a45;
 }
 
 .md-nav--secondary .md-nav__link--active {
-  color: #c0995e;
+  color: #d98a45;
   background-color: transparent;
-  border-left: 2px solid #c0995e;
+  border-left: 2px solid #d98a45;
 }
 
 .md-typeset a {
-  color: #c0995e;
+  color: #d98a45;
 }
 
 .md-typeset a:visited {
-  color: #c0995e;
+  color: #d98a45;
 }
 
 .md-typeset a:hover {
-  color: #d4b07c;
+  color: #e2a773;
 }
 
 .md-typeset a code,
 .md-typeset a:visited code {
-  color: #c0995e;
+  color: #d98a45;
   background-color: transparent;
   border-color: rgba(192, 153, 94, 0.3);
 }
 
 .md-typeset a:hover code {
-  color: #d4b07c;
+  color: #e2a773;
 }
 
 .md-header__button.md-logo {
@@ -155,7 +155,7 @@ a:hover {
 }
 
 .cp-navbar-links a {
-  color: #c0995e !important;
+  color: #d98a45 !important;
   text-decoration: none !important;
   font-family: "IBM Plex Sans", sans-serif;
   font-size: 16.8px !important;
@@ -175,7 +175,7 @@ a:hover {
   left: 0.85rem;
   right: 0.85rem;
   height: 2px;
-  background: #c0995e;
+  background: #d98a45;
   transform: scaleX(0);
   transition: transform 0.2s ease;
   border-radius: 1px;
@@ -183,7 +183,7 @@ a:hover {
 
 .cp-navbar-links a:hover,
 .cp-navbar-links a:focus {
-  color: #d4b07c !important;
+  color: #e2a773 !important;
   text-decoration: none !important;
 }
 
@@ -194,5 +194,5 @@ a:hover {
 }
 
 .cp-navbar-active {
-  color: #d4b07c !important;
+  color: #e2a773 !important;
 }

--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -1,3 +1,6 @@
+/* Accent gold #c0995e and light gold #d4b07c match --gold / --gold-light in
+   the website's _sass/SHB_css.scss. Keep the two in sync. */
+
 @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&display=swap');
 
 :root {
@@ -44,7 +47,7 @@ a:visited {
 }
 
 a:hover {
-  color: #d4b07a;
+  color: #d4b07c;
 }
 
 .md-nav__link--active,
@@ -68,7 +71,7 @@ a:hover {
 }
 
 .md-typeset a:hover {
-  color: #d4b07a;
+  color: #d4b07c;
 }
 
 .md-typeset a code,
@@ -79,7 +82,7 @@ a:hover {
 }
 
 .md-typeset a:hover code {
-  color: #d4b07a;
+  color: #d4b07c;
 }
 
 .md-header__button.md-logo {


### PR DESCRIPTION
Moves the docs accent from gold to a burnt orange closer to UT Austin's brand color, matching the same change on the website.

## Palette

| Role | Was | Now |
|---|---|---|
| Accent | `#c0995e` | `#d98a45` |
| Light / hover | `#d4b07a` and `#d4b07c` | `#e2a773` |

Hue moves from 36 degrees to 28; UT's Burnt Orange is 27.

## Contrast

Both values clear WCAG AA on the dark surface (`#242627`):

- accent `#d98a45` — **5.55:1** (old gold was 5.76:1)
- light `#e2a773` — **7.0:1**

UT's actual `#BF5700` was **not** used for the accent: at **3.31:1** on this background it falls below the 4.5:1 floor for body text, and the accent is used throughout as link text. On the website it is used for buttons, where white text on it scores 4.59:1.

## Also

The first commit collapses `#d4b07a` and `#d4b07c` — the file used both, one hex digit apart, for light gold. That distinction disappears here anyway, but it is split out so the typo fix is visible separately.

A header comment records that these values are duplicated from the website's `_sass/SHB_css.scss` and must stay in sync, since the two repos cannot share a stylesheet.

`mkdocs build --strict` and `markdownlint-cli2` both pass.